### PR TITLE
Issue with keep_open_window() on Visual Studio 2017

### DIFF
--- a/std_lib_facilities.h
+++ b/std_lib_facilities.h
@@ -163,6 +163,7 @@ template<class T> char* as_bytes(T& i)	// needed for binary I/O
 inline void keep_window_open()
 {
 	cin.clear();
+	cin.ignore(120,'\n');
 	cout << "Please enter a character to exit\n";
 	char ch;
 	cin >> ch;


### PR DESCRIPTION
keep_open_window() does not work with VS 2017.  When using the function, the console will immediately exit without printing the message to the user.

This issue was corrected by aligning both keep_open_window() functions.  By code inspection, this should not have any affect on other platforms.  This change was only tested on VS 2017.