### PR TITLE
Fix build errors encountered on lubuntu while attempting Chapter 12 Drill.

### DIFF
--- a/GUI.h
+++ b/GUI.h
@@ -92,9 +92,8 @@ namespace Graph_lib {
 
     struct Menu : Widget {
         enum Kind { horizontal, vertical };
-        Menu(Point xy, int w, int h, Kind kk, const string& label)
-            : Widget(xy,w,h,label,0), k(kk), offset(0)
-        {}
+	
+        Menu(Point xy, int w, int h, Kind kk, const string& label);
 
         Vector_ref<Button> selection;
         Kind k;

--- a/Graph.cpp
+++ b/Graph.cpp
@@ -310,7 +310,7 @@ bool can_open(const string& s)
             // check if a file named s exists and can be opened for reading
 {
 	ifstream ff(s.c_str());
-	return ff;
+	return static_cast<bool>(ff);
 }
 
 

--- a/Graph.h
+++ b/Graph.h
@@ -7,7 +7,7 @@
 //#include<string>
 //#include<cmath>
 #include "fltk.h"
-//#include "std_lib_facilities.h"
+#include "std_lib_facilities.h"
 
 namespace Graph_lib {
 // defense against ill-behaved Linux macros:

--- a/Point.h
+++ b/Point.h
@@ -8,8 +8,8 @@ namespace Graph_lib {
 
 struct Point {
 	int x,y;
-//	Point(int xx, int yy) : x(xx), y(yy) { }
-//	Point() :x(0), y(0) { }
+	Point(int xx, int yy) : x(xx), y(yy) { }
+	Point() :x(0), y(0) { }
 
 //	Point& operator+=(Point d) { x+=d.x; y+=d.y; return *this; }
 };

--- a/Simple_window.h
+++ b/Simple_window.h
@@ -6,7 +6,7 @@ using namespace Graph_lib;
 // Simple_window is basic scaffolding for ultra-simple interaction with graphics
 // it provides one window with one "next" button for ultra-simple animation
 
-struct Simple_window : Window {
+struct Simple_window :Graph_lib:: Window {
 	Simple_window(Point xy, int w, int h, const string& title )
 	: Window(xy,w,h,title),
 	  button_pushed(false),


### PR DESCRIPTION
Eliminates build errors encountered while attempting to use the files here to compile step 1 of the Chapter 12 Drill in PPP2 on the following linux system:
Kernel: Linux 4.15.0-101-generic (x86_64)
Default C Compiler: GNU C Compiler version 5.5.0 20171010 (Ubuntu 5.5.0-12ubuntu1~16.04) 
Distribution: Ubuntu 16.04.7 LTS
Desktop Environment: LXDE (Lubuntu)
FLTK: 1.3.5

Attribution: The "static_cast<bool>(ff);" change in Graph.cpp was given to me by someone who found it somewhere on the web. I do not know the original source.


